### PR TITLE
chore: update mathjax cdn

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -69,7 +69,7 @@
 {% endif %}
 
 <!-- MathJax -->
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
 <!-- =============== -->
 <!-- LINKS           -->

--- a/_includes/mathjax_support.html
+++ b/_includes/mathjax_support.html
@@ -15,9 +15,9 @@ MathJax.Hub.Register.MessageHook("Math Processing Error",function (message) {
 	  alert("Math Processing Error: "+message[1]);
 	});
 MathJax.Hub.Register.MessageHook("TeX Jax - parse error",function (message) {
-	  alert("Math Processing Error: "+message[1]);
-	});
+          alert("Math Processing Error: "+message[1]);
+        });
 </script>
 <script type="text/javascript" async
-  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
+  src="https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-MML-AM_CHTML">
 </script>


### PR DESCRIPTION
## Summary
- update MathJax CDN link for math support

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be8675d77c833099d504d432f115f6